### PR TITLE
Excise diagnostics only if activate extraction is set to true

### DIFF
--- a/Examples/BoostedBHComplexScalar/BoostedBHScalarLevel.cpp
+++ b/Examples/BoostedBHComplexScalar/BoostedBHScalarLevel.cpp
@@ -62,7 +62,7 @@ void BoostedBHScalarLevel::specificPostTimeStep()
                        disable_simd());
 
     // At any level, but after the timestep on the minimum extraction level
-    int min_level = m_p.extraction_params.min_extraction_level();
+    int min_level = 0.;
     bool calculate_diagnostics = at_level_timestep_multiple(min_level);
     if (calculate_diagnostics)
     {
@@ -80,16 +80,20 @@ void BoostedBHScalarLevel::specificPostTimeStep()
                        m_state_diagnostics, SKIP_GHOST_CELLS);
 
         // excise within/outside specified radii, no simd
-        BoxLoops::loop(
-            ExcisionDiagnostics<ScalarFieldWithPotential, BoostedBH>(
-                m_dx, m_p.center, boosted_bh, m_p.inner_r, m_p.outer_r),
-            m_state_diagnostics, m_state_diagnostics, SKIP_GHOST_CELLS,
-            disable_simd());
+        if (m_p.activate_extraction == 1)
+        {
+            BoxLoops::loop(
+                ExcisionDiagnostics<ScalarFieldWithPotential, BoostedBH>(
+                    m_dx, m_p.center, boosted_bh, m_p.inner_r, m_p.outer_r),
+                m_state_diagnostics, m_state_diagnostics, SKIP_GHOST_CELLS,
+                disable_simd());
+        }
     }
 
     // write out the integral after each timestep on the min_level
     if (m_p.activate_extraction == 1)
     {
+        min_level = m_p.extraction_params.min_extraction_level();
         if (m_level == min_level)
         {
             bool first_step = (m_time == m_dt);

--- a/Examples/BoostedBHComplexScalar/BoostedBHScalarLevel.cpp
+++ b/Examples/BoostedBHComplexScalar/BoostedBHScalarLevel.cpp
@@ -62,7 +62,10 @@ void BoostedBHScalarLevel::specificPostTimeStep()
                        disable_simd());
 
     // At any level, but after the timestep on the minimum extraction level
-    int min_level = 0.;
+    int min_level = 0;
+    if (m_p.activate_extraction == 1)
+        min_level = m_p.extraction_params.min_extraction_level();
+
     bool calculate_diagnostics = at_level_timestep_multiple(min_level);
     if (calculate_diagnostics)
     {
@@ -80,7 +83,7 @@ void BoostedBHScalarLevel::specificPostTimeStep()
                        m_state_diagnostics, SKIP_GHOST_CELLS);
 
         // excise within/outside specified radii, no simd
-        if (m_p.activate_extraction == 1)
+        if (m_p.activate_excision == 1)
         {
             BoxLoops::loop(
                 ExcisionDiagnostics<ScalarFieldWithPotential, BoostedBH>(
@@ -91,9 +94,8 @@ void BoostedBHScalarLevel::specificPostTimeStep()
     }
 
     // write out the integral after each timestep on the min_level
-    if (m_p.activate_extraction == 1)
+    if (m_p.activate_excision == 1)
     {
-        min_level = m_p.extraction_params.min_extraction_level();
         if (m_level == min_level)
         {
             bool first_step = (m_time == m_dt);
@@ -120,7 +122,13 @@ void BoostedBHScalarLevel::specificPostTimeStep()
                                                  "Lin. Mom. source"});
             }
             integral_file.write_time_data_line(data_for_writing);
+        }
+    }
 
+    if (m_p.activate_extraction == 1)
+    {
+        if (m_level == min_level)
+        {
             // Now refresh the interpolator and do the interpolation
             // only fill the actual ghost cells needed to save time
             bool fill_ghosts = false;

--- a/Examples/BoostedBHComplexScalar/SimulationParameters.hpp
+++ b/Examples/BoostedBHComplexScalar/SimulationParameters.hpp
@@ -36,8 +36,11 @@ class SimulationParameters : public FixedBGSimulationParametersBase
         pp.load("bh_center", bg_params.center, center);
 
         // Volume extraction radii
-        pp.load("inner_r", inner_r, extraction_params.extraction_radii[0]);
-        pp.load("outer_r", outer_r, extraction_params.extraction_radii[1]);
+        if (activate_extraction)
+        {
+            pp.load("inner_r", inner_r, extraction_params.extraction_radii[0]);
+            pp.load("outer_r", outer_r, extraction_params.extraction_radii[1]);
+        }
     }
 
     void check_params()
@@ -46,12 +49,15 @@ class SimulationParameters : public FixedBGSimulationParametersBase
                        initial_params.mass < 0.2 / coarsest_dx / dt_multiplier,
                        "oscillations of scalar field do not appear to be "
                        "resolved on coarsest level");
-        warn_parameter("inner_r", inner_r,
-                       extraction_params.extraction_radii[0] == inner_r,
-                       "should be equal to first extraction radius");
-        warn_parameter("outer_r", outer_r,
-                       extraction_params.extraction_radii[1] == outer_r,
-                       "should be equal to second extraction radius");
+        if (activate_extraction)
+        {
+            warn_parameter("inner_r", inner_r,
+                           extraction_params.extraction_radii[0] == inner_r,
+                           "should be equal to first extraction radius");
+            warn_parameter("outer_r", outer_r,
+                           extraction_params.extraction_radii[1] == outer_r,
+                           "should be equal to second extraction radius");
+        }
         warn_parameter("bh_mass", bg_params.mass, bg_params.mass >= 0.0,
                        "should be >= 0.0");
         FOR(idir)

--- a/Examples/BoostedBHComplexScalar/SimulationParameters.hpp
+++ b/Examples/BoostedBHComplexScalar/SimulationParameters.hpp
@@ -34,13 +34,6 @@ class SimulationParameters : public FixedBGSimulationParametersBase
         pp.load("bh_mass", bg_params.mass, 1.0);
         pp.load("bh_velocity", bg_params.velocity, 0.0);
         pp.load("bh_center", bg_params.center, center);
-
-        // Volume extraction radii
-        if (activate_extraction)
-        {
-            pp.load("inner_r", inner_r, extraction_params.extraction_radii[0]);
-            pp.load("outer_r", outer_r, extraction_params.extraction_radii[1]);
-        }
     }
 
     void check_params()
@@ -49,15 +42,6 @@ class SimulationParameters : public FixedBGSimulationParametersBase
                        initial_params.mass < 0.2 / coarsest_dx / dt_multiplier,
                        "oscillations of scalar field do not appear to be "
                        "resolved on coarsest level");
-        if (activate_extraction)
-        {
-            warn_parameter("inner_r", inner_r,
-                           extraction_params.extraction_radii[0] == inner_r,
-                           "should be equal to first extraction radius");
-            warn_parameter("outer_r", outer_r,
-                           extraction_params.extraction_radii[1] == outer_r,
-                           "should be equal to second extraction radius");
-        }
         warn_parameter("bh_mass", bg_params.mass, bg_params.mass >= 0.0,
                        "should be >= 0.0");
         FOR(idir)
@@ -71,8 +55,6 @@ class SimulationParameters : public FixedBGSimulationParametersBase
         }
     }
 
-    // Problem specific parameters - the radii for the integrations
-    double inner_r, outer_r;
     // Collection of parameters necessary for the initial conditions
     InitialScalarData::params_t initial_params;
     // Collection of parameters necessary for the metric background

--- a/Examples/BoostedBHComplexScalar/params.txt
+++ b/Examples/BoostedBHComplexScalar/params.txt
@@ -60,6 +60,8 @@ num_points_phi = 36
 num_points_theta = 24
 
 # For volume integrals
+# Default value is the same as activate_extraction
+# activate_excision = 1
 # By default these are set to the values of the extraction radii above
 # inner_r = 3.0
 # outer_r = 200.0

--- a/Examples/KerrBHScalarField/KerrBHScalarLevel.cpp
+++ b/Examples/KerrBHScalarField/KerrBHScalarLevel.cpp
@@ -78,7 +78,7 @@ void KerrBHScalarLevel::specificPostTimeStep()
                        disable_simd());
 
     // At any level, but after the min_level timestep
-    int min_level = m_p.extraction_params.min_extraction_level();
+    int min_level = 0.;
     bool calculate_diagnostics = at_level_timestep_multiple(min_level);
     if (calculate_diagnostics)
     {
@@ -94,16 +94,20 @@ void KerrBHScalarLevel::specificPostTimeStep()
                        m_state_diagnostics, SKIP_GHOST_CELLS);
 
         // excise within/outside specified radii, no simd
-        BoxLoops::loop(
-            ExcisionDiagnostics<ScalarFieldWithPotential, KerrSchild>(
-                m_dx, m_p.center, kerr_bh, m_p.inner_r, m_p.outer_r),
-            m_state_diagnostics, m_state_diagnostics, SKIP_GHOST_CELLS,
-            disable_simd());
+        if (m_p.activate_extraction == 1)
+        {
+            BoxLoops::loop(
+                ExcisionDiagnostics<ScalarFieldWithPotential, KerrSchild>(
+                    m_dx, m_p.center, kerr_bh, m_p.inner_r, m_p.outer_r),
+                m_state_diagnostics, m_state_diagnostics, SKIP_GHOST_CELLS,
+                disable_simd());
+        }
     }
 
     // write out the integral after each timestep on minimum level
     if (m_p.activate_extraction == 1)
     {
+        min_level = m_p.extraction_params.min_extraction_level();
         if (m_level == min_level)
         {
             bool first_step = (m_time == m_dt);

--- a/Examples/KerrBHScalarField/SimulationParameters.hpp
+++ b/Examples/KerrBHScalarField/SimulationParameters.hpp
@@ -38,8 +38,11 @@ class SimulationParameters : public FixedBGSimulationParametersBase
         pp.load("bh_center", bg_params.center, center);
 
         // Volume extraction radii
-        pp.load("inner_r", inner_r, extraction_params.extraction_radii[0]);
-        pp.load("outer_r", outer_r, extraction_params.extraction_radii[1]);
+        if (activate_extraction)
+        {
+            pp.load("inner_r", inner_r, extraction_params.extraction_radii[0]);
+            pp.load("outer_r", outer_r, extraction_params.extraction_radii[1]);
+        }
     }
 
     void check_params()
@@ -50,12 +53,15 @@ class SimulationParameters : public FixedBGSimulationParametersBase
                        "resolved on coarsest level");
         warn_parameter("bh_mass", bg_params.mass, bg_params.mass >= 0.0,
                        "should be >= 0.0");
-        warn_parameter("inner_r", inner_r,
-                       extraction_params.extraction_radii[0] == inner_r,
-                       "should be equal to first extraction radius");
-        warn_parameter("outer_r", outer_r,
-                       extraction_params.extraction_radii[1] == outer_r,
-                       "should be equal to second extraction radius");
+        if (activate_extraction)
+        {
+            warn_parameter("inner_r", inner_r,
+                           extraction_params.extraction_radii[0] == inner_r,
+                           "should be equal to first extraction radius");
+            warn_parameter("outer_r", outer_r,
+                           extraction_params.extraction_radii[1] == outer_r,
+                           "should be equal to second extraction radius");
+        }
         check_parameter("bh_spin", bg_params.spin,
                         std::abs(bg_params.spin) <= bg_params.mass,
                         "must satisfy |a| <= M = " +

--- a/Examples/KerrBHScalarField/SimulationParameters.hpp
+++ b/Examples/KerrBHScalarField/SimulationParameters.hpp
@@ -36,13 +36,6 @@ class SimulationParameters : public FixedBGSimulationParametersBase
         pp.load("bh_mass", bg_params.mass, 1.0);
         pp.load("bh_spin", bg_params.spin, 0.0);
         pp.load("bh_center", bg_params.center, center);
-
-        // Volume extraction radii
-        if (activate_extraction)
-        {
-            pp.load("inner_r", inner_r, extraction_params.extraction_radii[0]);
-            pp.load("outer_r", outer_r, extraction_params.extraction_radii[1]);
-        }
     }
 
     void check_params()
@@ -53,15 +46,7 @@ class SimulationParameters : public FixedBGSimulationParametersBase
                        "resolved on coarsest level");
         warn_parameter("bh_mass", bg_params.mass, bg_params.mass >= 0.0,
                        "should be >= 0.0");
-        if (activate_extraction)
-        {
-            warn_parameter("inner_r", inner_r,
-                           extraction_params.extraction_radii[0] == inner_r,
-                           "should be equal to first extraction radius");
-            warn_parameter("outer_r", outer_r,
-                           extraction_params.extraction_radii[1] == outer_r,
-                           "should be equal to second extraction radius");
-        }
+
         check_parameter("bh_spin", bg_params.spin,
                         std::abs(bg_params.spin) <= bg_params.mass,
                         "must satisfy |a| <= M = " +
@@ -77,8 +62,6 @@ class SimulationParameters : public FixedBGSimulationParametersBase
         }
     }
 
-    // Problem specific parameters
-    double inner_r, outer_r;
     // Collection of parameters necessary for the initial conditions
     InitialScalarData::params_t initial_params;
     // Collection of parameters necessary for the background metric

--- a/Examples/KerrBHScalarField/params.txt
+++ b/Examples/KerrBHScalarField/params.txt
@@ -59,7 +59,9 @@ num_points_phi = 36
 num_points_theta = 24
 
 # For volume integrals
-# defaulted to extraction radii values above
+# Default value is the same as activate_extraction
+# activate_excision = 1
+# By default these are set to the values of the extraction radii above
 # inner_r = 7.0
 # outer_r = 110.0
 

--- a/Source/Background/FixedBGSimulationParametersBase.hpp
+++ b/Source/Background/FixedBGSimulationParametersBase.hpp
@@ -46,7 +46,8 @@ class FixedBGSimulationParametersBase : public ChomboParameters
             FilesystemTools::mkdir_recursive(data_path);
 
         // Extraction params
-        pp.load("activate_extraction", activate_extraction, false);
+        pp.load("activate_extraction", activate_extraction, true);
+        pp.load("activate_excision", activate_excision, activate_extraction);
 
         if (activate_extraction)
         {
@@ -97,6 +98,23 @@ class FixedBGSimulationParametersBase : public ChomboParameters
 
             pp.load("write_extraction", extraction_params.write_extraction,
                     false);
+        }
+
+        // For volume extraction and excision of diagnostic variables
+        if (activate_excision)
+        {
+            if (activate_extraction)
+            {
+                pp.load("inner_r", inner_r,
+                        extraction_params.extraction_radii[0]);
+                pp.load("outer_r", outer_r,
+                        extraction_params.extraction_radii[1]);
+            }
+            else
+            {
+                pp.load("inner_r", inner_r, 3.);
+                pp.load("outer_r", outer_r, L / 4.);
+            }
         }
     }
 
@@ -161,6 +179,16 @@ class FixedBGSimulationParametersBase : public ChomboParameters
                     "l must be >= 2 and m must satisfy -l <= m <= l");
             }
         }
+
+        if (activate_extraction && activate_excision)
+        {
+            warn_parameter("inner_r", inner_r,
+                           extraction_params.extraction_radii[0] == inner_r,
+                           "should be equal to first extraction radius");
+            warn_parameter("outer_r", outer_r,
+                           extraction_params.extraction_radii[1] == outer_r,
+                           "should be equal to second extraction radius");
+        }
     }
 
   public:
@@ -168,8 +196,9 @@ class FixedBGSimulationParametersBase : public ChomboParameters
     int nan_check;
 
     // Collection of parameters necessary for the extraction
-    bool activate_extraction;
+    bool activate_extraction, activate_excision;
     spherical_extraction_params_t extraction_params;
+    double inner_r, outer_r;
 
     std::string data_path;
 };


### PR DESCRIPTION
Fix issue with loading inner_r and outer_r variables.
They're only necessary if you want to extract the integrals of the diagnostic variables.